### PR TITLE
Fixing typo and altering eqn 277 in GROUPR section

### DIFF
--- a/groupx.tex
+++ b/groupx.tex
@@ -737,10 +737,10 @@ a constant cross section.  The full equation is
 
   \begin{eqnarray}
     [\sigma_0+\sigma_t(E)]\,\phi_f(E)&=&
-    (1-\beta)\,{C(E)\,\sigma_0}\nonumber\\
-    &+&\int_E^{E/\alpha_3}{{\beta(1-\gamma)(\sigma_0-\sigma_{am}}\over
+      (1-\beta)\,{C(E)\,(\sigma_0-\sigma_{am})}\nonumber\\
+      &+&\int_E^{E/\alpha_3}{{\beta(1-\gamma)(\sigma_0-\sigma_{am})}\over
     {(1-\alpha_3)E'}}\,\phi_f(E')\,dE'\nonumber\\
-    &+&\int_E^{E/\alpha_2}{{\sigma_{am}+\beta\gamma(\sigma_0-\sigma_{am}}\over
+      &+&\int_E^{E/\alpha_2}{{\sigma_{am}+\beta\gamma(\sigma_0-\sigma_{am})}\over
     {(1-\alpha_2)E'}}\,\phi_f(E')\,dE'\nonumber\\
     &+&\int_E^{E/\alpha_f}{{\sigma_{sf}(E')} \over
     {(1-\alpha_f)E'}}\,\phi_f(E')\,dE'\,\,,


### PR DESCRIPTION
- Added closing parentheses to the $(\sigma_0 - \sigma_{am})$ terms in the two integral terms
- Changed the smooth weight function $C(E)$ term from $(1-\beta)C(E)\sigma_{0}$ to $(1-\beta)C(E)(\sigma_{0} - \sigma_{am})$
  - This is consistent with its implementation in the NJOY16 groupr.f90 file, in genflx subr, line 5349 at time of writing
  - i.e. `b(iz+3+li)=(sigz(iz)-sam)*wtf*(1-beta)`
  - Also consistent I believe with the maths as the derivation of eqn. 277 suggests $\frac{\sigma_{e}}{\rho_{f}} = \sigma_0 - \sigma_{am}$ 
- I realise I should also recompile the njoy16.pdf file included but I don't think I have all the packages required so perhaps someone more competent could do that.